### PR TITLE
Print a warning if the CI Server is not known

### DIFF
--- a/main.go
+++ b/main.go
@@ -197,5 +197,12 @@ func main() {
 		}
 		endOfLifeHelper.sendBuildFinishedEvent(buildStatus)
 		os.Exit(0)
+	} else {
+		// Set up a simple console logger
+		log.Logger = zerolog.New(zerolog.ConsoleWriter{Out: os.Stderr}).With().
+			Timestamp().
+			Logger()
+
+		log.Warn().Msgf("The CI Server (\"%s\") is not recognized, exiting.", ciServer)
 	}
 }


### PR DESCRIPTION
If we weren't in GoCD or the Estafette server, the CLI just silently exited without any message. With this PR we're printing a warning. If there is no CI server env var:
```
$ estafette-ci-builder
2018-06-19T12:07:30+02:00 |WARN| The CI Server ("") is not recognized, exiting.
```
Or if it's unknown:
```
$ estafette-ci-builder
2018-06-19T12:07:30+02:00 |WARN| The CI Server ("foo") is not recognized, exiting.
```