### PR TITLE
keep multi-stage service containers running until all stages are done

### DIFF
--- a/dockerRunner.go
+++ b/dockerRunner.go
@@ -366,6 +366,7 @@ func (dr *dockerRunnerImpl) StartServiceContainer(ctx context.Context, envvars m
 	resp, err := dr.dockerClient.ContainerCreate(ctx, &config, &container.HostConfig{
 		Binds:      binds,
 		Privileged: privileged,
+		AutoRemove: true,
 	}, &network.NetworkingConfig{}, service.Name)
 	if err != nil {
 		return

--- a/dockerRunner.go
+++ b/dockerRunner.go
@@ -916,7 +916,7 @@ func (dr *dockerRunnerImpl) generateEntrypointScript(shell string, commands []st
 			Command         string
 			EscapedCommand  string
 			RunInBackground bool
-		}{c, strings.Replace(c, "'", "\\'", -1), runInBackground})
+		}{c, strings.Replace(c, "\"", "\\\"", -1), runInBackground})
 	}
 
 	lastCommand := commands[len(commands)-1]
@@ -937,7 +937,7 @@ func (dr *dockerRunnerImpl) generateEntrypointScript(shell string, commands []st
 		shell,
 		firstCommands,
 		lastCommand,
-		strings.Replace(lastCommand, "'", "\\'", -1),
+		strings.Replace(lastCommand, "\"", "\\\"", -1),
 		runFinalCommandWithExec,
 	}
 

--- a/dockerRunner_test.go
+++ b/dockerRunner_test.go
@@ -177,7 +177,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> go test ./... &\\x1b[0m\"\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> go test ./... &\\x1b[0m\"\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait $!\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunVariableAssignmentInBackground", func(t *testing.T) {
@@ -196,7 +196,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> go test ./... &\\x1b[0m\"\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\necho -e \"\\x1b[38;5;250m> export MY_TITLE_2=abc\\x1b[0m\"\nexport MY_TITLE_2=abc\necho -e \"\\x1b[38;5;250m> echo $MY_TITLE_2 &\\x1b[0m\"\necho $MY_TITLE_2 &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> go test ./... &\\x1b[0m\"\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait $!\necho -e \"\\x1b[38;5;250m> export MY_TITLE_2=abc\\x1b[0m\"\nexport MY_TITLE_2=abc\necho -e \"\\x1b[38;5;250m> echo $MY_TITLE_2 &\\x1b[0m\"\necho $MY_TITLE_2 &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait $!\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithOrInBackground", func(t *testing.T) {

--- a/dockerRunner_test.go
+++ b/dockerRunner_test.go
@@ -158,7 +158,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e $'\\x1b[38;5;250m> exec go test ./...\\x1b[0m'\nexec go test ./...", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e \"\\x1b[38;5;250m> exec go test ./...\\x1b[0m\"\nexec go test ./...", string(bytes))
 	})
 
 	t.Run("ReturnsVariablesForTwoOrMoreCommands", func(t *testing.T) {
@@ -177,7 +177,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> go test ./... &\\x1b[0m'\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> go test ./... &\\x1b[0m\"\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunVariableAssignmentInBackground", func(t *testing.T) {
@@ -196,7 +196,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> go test ./... &\\x1b[0m'\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\necho -e $'\\x1b[38;5;250m> export MY_TITLE_2=abc\\x1b[0m'\nexport MY_TITLE_2=abc\necho -e $'\\x1b[38;5;250m> echo $MY_TITLE_2 &\\x1b[0m'\necho $MY_TITLE_2 &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> go test ./... &\\x1b[0m\"\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\necho -e \"\\x1b[38;5;250m> export MY_TITLE_2=abc\\x1b[0m\"\nexport MY_TITLE_2=abc\necho -e \"\\x1b[38;5;250m> echo $MY_TITLE_2 &\\x1b[0m\"\necho $MY_TITLE_2 &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithOrInBackground", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> false || true\\x1b[0m'\nfalse || true\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> false || true\\x1b[0m\"\nfalse || true\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithAndInBackground", func(t *testing.T) {
@@ -234,7 +234,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> false && true\\x1b[0m'\nfalse && true\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> false && true\\x1b[0m\"\nfalse && true\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithPipeInBackground", func(t *testing.T) {
@@ -253,7 +253,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> cat kubernetes.yaml | kubectl apply -f -\\x1b[0m'\ncat kubernetes.yaml | kubectl apply -f -\n\necho -e $'\\x1b[38;5;250m> exec kubectl rollout status deploy/myapp\\x1b[0m'\nexec kubectl rollout status deploy/myapp", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> cat kubernetes.yaml | kubectl apply -f -\\x1b[0m\"\ncat kubernetes.yaml | kubectl apply -f -\n\necho -e \"\\x1b[38;5;250m> exec kubectl rollout status deploy/myapp\\x1b[0m\"\nexec kubectl rollout status deploy/myapp", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithChangeDirectoryInBackground", func(t *testing.T) {
@@ -272,7 +272,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> cd subdir\\x1b[0m'\ncd subdir\n\necho -e $'\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> cd subdir\\x1b[0m\"\ncd subdir\n\necho -e \"\\x1b[38;5;250m> exec ls -latr\\x1b[0m\"\nexec ls -latr", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithExportInBackground", func(t *testing.T) {
@@ -291,7 +291,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> export $(python3 requiredenv.py)\\x1b[0m'\nexport $(python3 requiredenv.py)\n\necho -e $'\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> export $(python3 requiredenv.py)\\x1b[0m\"\nexport $(python3 requiredenv.py)\n\necho -e \"\\x1b[38;5;250m> exec ls -latr\\x1b[0m\"\nexec ls -latr", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithShoptInBackground", func(t *testing.T) {
@@ -310,7 +310,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> shopt -u dotglob\\x1b[0m'\nshopt -u dotglob\n\necho -e $'\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> shopt -u dotglob\\x1b[0m\"\nshopt -u dotglob\n\necho -e \"\\x1b[38;5;250m> exec ls -latr\\x1b[0m\"\nexec ls -latr", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithSemicolonInBackground", func(t *testing.T) {
@@ -329,10 +329,10 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> if [ \"${VARIABLE}\" -ne \"\" ]; then echo $VARIABLE; fi\\x1b[0m'\nif [ \"${VARIABLE}\" -ne \"\" ]; then echo $VARIABLE; fi\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> if [ \\\"${VARIABLE}\\\" -ne \\\"\\\" ]; then echo $VARIABLE; fi\\x1b[0m\"\nif [ \"${VARIABLE}\" -ne \"\" ]; then echo $VARIABLE; fi\n\necho -e \"\\x1b[38;5;250m> exec go build\\x1b[0m\"\nexec go build", string(bytes))
 	})
 
-	t.Run("DoesNotEscapeDoubleQuotesInEchoStatements", func(t *testing.T) {
+	t.Run("EscapesDoubleQuotesInEchoStatements", func(t *testing.T) {
 
 		dockerRunner := dockerRunnerImpl{
 			entrypointTemplateDir: "./templates",
@@ -348,10 +348,10 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e $'\\x1b[38;5;250m> exec echo \"<xml />\"\\x1b[0m'\nexec echo \"<xml />\"", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e \"\\x1b[38;5;250m> exec echo \\\"<xml />\\\"\\x1b[0m\"\nexec echo \"<xml />\"", string(bytes))
 	})
 
-	t.Run("EscapesSingleQuotesInEchoStatements", func(t *testing.T) {
+	t.Run("DoesNotEscapeSingleQuotesInEchoStatements", func(t *testing.T) {
 
 		dockerRunner := dockerRunnerImpl{
 			entrypointTemplateDir: "./templates",
@@ -367,7 +367,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e $'\\x1b[38;5;250m> exec echo \\'<xml />\\'\\x1b[0m'\nexec echo '<xml />'", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e \"\\x1b[38;5;250m> exec echo '<xml />'\\x1b[0m\"\nexec echo '<xml />'", string(bytes))
 	})
 
 	t.Run("DoesNotRunAnyCommandInBackgroundWhenRunCommandsInForegroundIsTrue", func(t *testing.T) {
@@ -386,7 +386,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> go test ./...\\x1b[0m'\ngo test ./...\n\necho -e $'\\x1b[38;5;250m> go build\\x1b[0m'\ngo build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e \"\\x1b[38;5;250m> go test ./...\\x1b[0m\"\ngo test ./...\n\necho -e \"\\x1b[38;5;250m> go build\\x1b[0m\"\ngo build", string(bytes))
 	})
 }
 

--- a/dockerRunner_test.go
+++ b/dockerRunner_test.go
@@ -158,7 +158,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e '\\x1b[38;5;250m> exec go test ./...\\x1b[0m'\nexec go test ./...", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e $'\\x1b[38;5;250m> exec go test ./...\\x1b[0m'\nexec go test ./...", string(bytes))
 	})
 
 	t.Run("ReturnsVariablesForTwoOrMoreCommands", func(t *testing.T) {
@@ -177,7 +177,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> go test ./... &\\x1b[0m'\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e '\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> go test ./... &\\x1b[0m'\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunVariableAssignmentInBackground", func(t *testing.T) {
@@ -196,7 +196,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> go test ./... &\\x1b[0m'\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\necho -e '\\x1b[38;5;250m> export MY_TITLE_2=abc\\x1b[0m'\nexport MY_TITLE_2=abc\necho -e '\\x1b[38;5;250m> echo $MY_TITLE_2 &\\x1b[0m'\necho $MY_TITLE_2 &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e '\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> go test ./... &\\x1b[0m'\ngo test ./... &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\necho -e $'\\x1b[38;5;250m> export MY_TITLE_2=abc\\x1b[0m'\nexport MY_TITLE_2=abc\necho -e $'\\x1b[38;5;250m> echo $MY_TITLE_2 &\\x1b[0m'\necho $MY_TITLE_2 &\ntrap \"kill $!; wait; exit\" 1 2 15\nwait\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithOrInBackground", func(t *testing.T) {
@@ -215,7 +215,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> false || true\\x1b[0m'\nfalse || true\n\necho -e '\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> false || true\\x1b[0m'\nfalse || true\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithAndInBackground", func(t *testing.T) {
@@ -234,7 +234,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> false && true\\x1b[0m'\nfalse && true\n\necho -e '\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> false && true\\x1b[0m'\nfalse && true\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithPipeInBackground", func(t *testing.T) {
@@ -253,7 +253,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> cat kubernetes.yaml | kubectl apply -f -\\x1b[0m'\ncat kubernetes.yaml | kubectl apply -f -\n\necho -e '\\x1b[38;5;250m> exec kubectl rollout status deploy/myapp\\x1b[0m'\nexec kubectl rollout status deploy/myapp", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> cat kubernetes.yaml | kubectl apply -f -\\x1b[0m'\ncat kubernetes.yaml | kubectl apply -f -\n\necho -e $'\\x1b[38;5;250m> exec kubectl rollout status deploy/myapp\\x1b[0m'\nexec kubectl rollout status deploy/myapp", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithChangeDirectoryInBackground", func(t *testing.T) {
@@ -272,7 +272,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> cd subdir\\x1b[0m'\ncd subdir\n\necho -e '\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> cd subdir\\x1b[0m'\ncd subdir\n\necho -e $'\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithExportInBackground", func(t *testing.T) {
@@ -291,7 +291,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> export $(python3 requiredenv.py)\\x1b[0m'\nexport $(python3 requiredenv.py)\n\necho -e '\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> export $(python3 requiredenv.py)\\x1b[0m'\nexport $(python3 requiredenv.py)\n\necho -e $'\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithShoptInBackground", func(t *testing.T) {
@@ -310,7 +310,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> shopt -u dotglob\\x1b[0m'\nshopt -u dotglob\n\necho -e '\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> shopt -u dotglob\\x1b[0m'\nshopt -u dotglob\n\necho -e $'\\x1b[38;5;250m> exec ls -latr\\x1b[0m'\nexec ls -latr", string(bytes))
 	})
 
 	t.Run("DoesNotRunCommandsWithSemicolonInBackground", func(t *testing.T) {
@@ -329,7 +329,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> if [ \"${VARIABLE}\" -ne \"\" ]; then echo $VARIABLE; fi\\x1b[0m'\nif [ \"${VARIABLE}\" -ne \"\" ]; then echo $VARIABLE; fi\n\necho -e '\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> if [ \"${VARIABLE}\" -ne \"\" ]; then echo $VARIABLE; fi\\x1b[0m'\nif [ \"${VARIABLE}\" -ne \"\" ]; then echo $VARIABLE; fi\n\necho -e $'\\x1b[38;5;250m> exec go build\\x1b[0m'\nexec go build", string(bytes))
 	})
 
 	t.Run("DoesNotEscapeDoubleQuotesInEchoStatements", func(t *testing.T) {
@@ -348,7 +348,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e '\\x1b[38;5;250m> exec echo \"<xml />\"\\x1b[0m'\nexec echo \"<xml />\"", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e $'\\x1b[38;5;250m> exec echo \"<xml />\"\\x1b[0m'\nexec echo \"<xml />\"", string(bytes))
 	})
 
 	t.Run("EscapesSingleQuotesInEchoStatements", func(t *testing.T) {
@@ -367,7 +367,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e '\\x1b[38;5;250m> exec echo \\'<xml />\\'\\x1b[0m'\nexec echo '<xml />'", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\n\necho -e $'\\x1b[38;5;250m> exec echo \\'<xml />\\'\\x1b[0m'\nexec echo '<xml />'", string(bytes))
 	})
 
 	t.Run("DoesNotRunAnyCommandInBackgroundWhenRunCommandsInForegroundIsTrue", func(t *testing.T) {
@@ -386,7 +386,7 @@ func TestGenerateEntrypointScript(t *testing.T) {
 
 		bytes, err := ioutil.ReadFile(path)
 		assert.Nil(t, err)
-		assert.Equal(t, "#!/bin/sh\nset -e\necho -e '\\x1b[38;5;250m> go test ./...\\x1b[0m'\ngo test ./...\n\necho -e '\\x1b[38;5;250m> go build\\x1b[0m'\ngo build", string(bytes))
+		assert.Equal(t, "#!/bin/sh\nset -e\necho -e $'\\x1b[38;5;250m> go test ./...\\x1b[0m'\ngo test ./...\n\necho -e $'\\x1b[38;5;250m> go build\\x1b[0m'\ngo build", string(bytes))
 	})
 }
 

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/estafette/estafette-ci-contracts v0.0.177
+	github.com/estafette/estafette-ci-contracts v0.0.178
 	github.com/estafette/estafette-ci-crypt v0.0.27
-	github.com/estafette/estafette-ci-manifest v0.1.136
+	github.com/estafette/estafette-ci-manifest v0.1.137
 	github.com/estafette/estafette-foundation v0.0.32
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect

--- a/go.mod
+++ b/go.mod
@@ -14,9 +14,9 @@ require (
 	github.com/docker/docker v1.13.1
 	github.com/docker/go-connections v0.4.0 // indirect
 	github.com/docker/go-units v0.4.0 // indirect
-	github.com/estafette/estafette-ci-contracts v0.0.178
+	github.com/estafette/estafette-ci-contracts v0.0.179
 	github.com/estafette/estafette-ci-crypt v0.0.27
-	github.com/estafette/estafette-ci-manifest v0.1.137
+	github.com/estafette/estafette-ci-manifest v0.1.138
 	github.com/estafette/estafette-foundation v0.0.32
 	github.com/gogo/protobuf v1.3.0 // indirect
 	github.com/google/go-cmp v0.3.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -35,10 +35,14 @@ github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
 github.com/estafette/estafette-ci-contracts v0.0.178 h1:BugwtND8ff0X7JcPGjh/8NHGhE92E8T6ynyIMy4Pstw=
 github.com/estafette/estafette-ci-contracts v0.0.178/go.mod h1:UvWqVs3Nsgeg6nk/MmxzK/ajaAD/dDEPsUjVN9FOFWc=
+github.com/estafette/estafette-ci-contracts v0.0.179 h1:LNINv1FDw+Jdvb2dES/w4qYykP9aSALX0e2eYpfKXsU=
+github.com/estafette/estafette-ci-contracts v0.0.179/go.mod h1:CTpeCf299TmxXHDi4P7eEjkQAinxkUI4JTMnv34QVns=
 github.com/estafette/estafette-ci-crypt v0.0.27 h1:+5lB+TjhPZp/xtnhAzIoQNIIdReS/BjN7KaI/aPoslM=
 github.com/estafette/estafette-ci-crypt v0.0.27/go.mod h1:yODzGbzW7Jj0xEFjAv1Is+FHcYaugHUtrPdkJdHV8/c=
 github.com/estafette/estafette-ci-manifest v0.1.137 h1:yVrAVZZepNiIe3/kesJaGETS+XMjSkSgfit1smqyxbw=
 github.com/estafette/estafette-ci-manifest v0.1.137/go.mod h1:tJKMaXeTc7L45SP7/ueP57EIvx95QL6Z9dZiJiyGCzY=
+github.com/estafette/estafette-ci-manifest v0.1.138 h1:SUUOBzPGd0ixnvmyIaQhCIbv42mn5XLcQpfRKSSnz+8=
+github.com/estafette/estafette-ci-manifest v0.1.138/go.mod h1:tJKMaXeTc7L45SP7/ueP57EIvx95QL6Z9dZiJiyGCzY=
 github.com/estafette/estafette-foundation v0.0.32 h1:s32Gt59N1+tkv5CKbtPtCtxGFqXUecfl9v9/IB1sv9I=
 github.com/estafette/estafette-foundation v0.0.32/go.mod h1:pgqDp5MyMR9PgRFwU5w7zb8XAa8hkyaf51Sutl04llY=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/go.sum
+++ b/go.sum
@@ -33,14 +33,10 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/estafette/estafette-ci-contracts v0.0.178 h1:BugwtND8ff0X7JcPGjh/8NHGhE92E8T6ynyIMy4Pstw=
-github.com/estafette/estafette-ci-contracts v0.0.178/go.mod h1:UvWqVs3Nsgeg6nk/MmxzK/ajaAD/dDEPsUjVN9FOFWc=
 github.com/estafette/estafette-ci-contracts v0.0.179 h1:LNINv1FDw+Jdvb2dES/w4qYykP9aSALX0e2eYpfKXsU=
 github.com/estafette/estafette-ci-contracts v0.0.179/go.mod h1:CTpeCf299TmxXHDi4P7eEjkQAinxkUI4JTMnv34QVns=
 github.com/estafette/estafette-ci-crypt v0.0.27 h1:+5lB+TjhPZp/xtnhAzIoQNIIdReS/BjN7KaI/aPoslM=
 github.com/estafette/estafette-ci-crypt v0.0.27/go.mod h1:yODzGbzW7Jj0xEFjAv1Is+FHcYaugHUtrPdkJdHV8/c=
-github.com/estafette/estafette-ci-manifest v0.1.137 h1:yVrAVZZepNiIe3/kesJaGETS+XMjSkSgfit1smqyxbw=
-github.com/estafette/estafette-ci-manifest v0.1.137/go.mod h1:tJKMaXeTc7L45SP7/ueP57EIvx95QL6Z9dZiJiyGCzY=
 github.com/estafette/estafette-ci-manifest v0.1.138 h1:SUUOBzPGd0ixnvmyIaQhCIbv42mn5XLcQpfRKSSnz+8=
 github.com/estafette/estafette-ci-manifest v0.1.138/go.mod h1:tJKMaXeTc7L45SP7/ueP57EIvx95QL6Z9dZiJiyGCzY=
 github.com/estafette/estafette-foundation v0.0.32 h1:s32Gt59N1+tkv5CKbtPtCtxGFqXUecfl9v9/IB1sv9I=

--- a/go.sum
+++ b/go.sum
@@ -33,12 +33,12 @@ github.com/docker/go-connections v0.4.0 h1:El9xVISelRB7BuFusrZozjnkIM5YnzCViNKoh
 github.com/docker/go-connections v0.4.0/go.mod h1:Gbd7IOopHjR8Iph03tsViu4nIes5XhDvyHbTtUxmeec=
 github.com/docker/go-units v0.4.0 h1:3uh0PgVws3nIA0Q+MwDC8yjEPf9zjRfZZWXZYDct3Tw=
 github.com/docker/go-units v0.4.0/go.mod h1:fgPhTUdO+D/Jk86RDLlptpiXQzgHJF7gydDDbaIK4Dk=
-github.com/estafette/estafette-ci-contracts v0.0.177 h1:TEbhLF8LmBzA7C2BRQuRtrrzVmSybEveB1ZlZWjhT/Q=
-github.com/estafette/estafette-ci-contracts v0.0.177/go.mod h1:VfN3AaeTVnKikE+5tT+NuOdXkYb1eP4zUsw5zy41qjA=
+github.com/estafette/estafette-ci-contracts v0.0.178 h1:BugwtND8ff0X7JcPGjh/8NHGhE92E8T6ynyIMy4Pstw=
+github.com/estafette/estafette-ci-contracts v0.0.178/go.mod h1:UvWqVs3Nsgeg6nk/MmxzK/ajaAD/dDEPsUjVN9FOFWc=
 github.com/estafette/estafette-ci-crypt v0.0.27 h1:+5lB+TjhPZp/xtnhAzIoQNIIdReS/BjN7KaI/aPoslM=
 github.com/estafette/estafette-ci-crypt v0.0.27/go.mod h1:yODzGbzW7Jj0xEFjAv1Is+FHcYaugHUtrPdkJdHV8/c=
-github.com/estafette/estafette-ci-manifest v0.1.136 h1:1tetHESEvytu2jFTly7L9v3ofYvQi6r1ClBhr/An3os=
-github.com/estafette/estafette-ci-manifest v0.1.136/go.mod h1:tJKMaXeTc7L45SP7/ueP57EIvx95QL6Z9dZiJiyGCzY=
+github.com/estafette/estafette-ci-manifest v0.1.137 h1:yVrAVZZepNiIe3/kesJaGETS+XMjSkSgfit1smqyxbw=
+github.com/estafette/estafette-ci-manifest v0.1.137/go.mod h1:tJKMaXeTc7L45SP7/ueP57EIvx95QL6Z9dZiJiyGCzY=
 github.com/estafette/estafette-foundation v0.0.32 h1:s32Gt59N1+tkv5CKbtPtCtxGFqXUecfl9v9/IB1sv9I=
 github.com/estafette/estafette-foundation v0.0.32/go.mod h1:pgqDp5MyMR9PgRFwU5w7zb8XAa8hkyaf51Sutl04llY=
 github.com/fsnotify/fsnotify v1.4.7 h1:IXs+QLmnXW2CcXuY+8Mzv/fWEsPGWxqefPtCP5CnV9I=

--- a/pipelineRunner.go
+++ b/pipelineRunner.go
@@ -87,7 +87,7 @@ func (pr *pipelineRunnerImpl) RunStage(ctx context.Context, depth int, runIndex 
 		} else {
 			log.Warn().Msgf("%v Can't run parallel stages nested inside nested stages", stagePlaceholder)
 		}
-	} else {
+	} else if stage.ContainerImage != "" {
 		var containerID string
 		containerID, err = pr.dockerRunner.StartStageContainer(ctx, depth, runIndex, dir, envvars, stage)
 		if err != nil {

--- a/pipelineRunner.go
+++ b/pipelineRunner.go
@@ -668,7 +668,7 @@ func (pr *pipelineRunnerImpl) forceStatusForStage(stage manifest.EstafetteStage,
 
 func (pr *pipelineRunnerImpl) tailLogs(ctx context.Context, tailLogsDone chan struct{}, stages []*manifest.EstafetteStage) {
 
-	stageExecutionDone := make(chan struct{}, 1)
+	allLogsReceived := make(chan struct{}, 1)
 
 	for {
 		select {
@@ -689,10 +689,10 @@ func (pr *pipelineRunnerImpl) tailLogs(ctx context.Context, tailLogsDone chan st
 
 			if tailLogLine.Status != nil && pr.isFinalStageComplete(stages) {
 				// signal that running stages have finished so taillogs can stop
-				stageExecutionDone <- struct{}{}
+				allLogsReceived <- struct{}{}
 			}
 
-		case <-stageExecutionDone:
+		case <-allLogsReceived:
 			// signal that tailing logs is done
 			tailLogsDone <- struct{}{}
 			return

--- a/pipelineRunner.go
+++ b/pipelineRunner.go
@@ -892,6 +892,7 @@ func (pr *pipelineRunnerImpl) isFinalStageComplete(stages []*manifest.EstafetteS
 			return false
 		}
 
+		// check that all parallel stages are done
 		allNestedStepsAreDone := true
 		for _, ns := range lastBuildLogsStep.NestedSteps {
 			switch ns.Status {
@@ -908,16 +909,19 @@ func (pr *pipelineRunnerImpl) isFinalStageComplete(stages []*manifest.EstafetteS
 			return false
 		}
 
+		// check that all service containers are done
 		allNestedServicesAreDone := true
-		for _, s := range lastBuildLogsStep.Services {
-			switch s.Status {
-			case contracts.StatusSucceeded,
-				contracts.StatusFailed,
-				contracts.StatusSkipped,
-				contracts.StatusCanceled:
+		for _, st := range pr.buildLogSteps {
+			for _, s := range st.Services {
+				switch s.Status {
+				case contracts.StatusSucceeded,
+					contracts.StatusFailed,
+					contracts.StatusSkipped,
+					contracts.StatusCanceled:
 
-			default:
-				allNestedServicesAreDone = false
+				default:
+					allNestedServicesAreDone = false
+				}
 			}
 		}
 		if !allNestedServicesAreDone {

--- a/pipelineRunner_test.go
+++ b/pipelineRunner_test.go
@@ -1857,6 +1857,26 @@ func TestUpsertTailLogLine(t *testing.T) {
 		assert.Equal(t, "stage-a", pipelineRunner.buildLogSteps[0].Step)
 	})
 
+	t.Run("AddsMainStageWithDepth0IfServiceContainerStatusComesInFirst", func(t *testing.T) {
+
+		pipelineRunner := pipelineRunnerImpl{
+			buildLogSteps: make([]*contracts.BuildLogStep, 0),
+		}
+		tailLogLine := contracts.TailLogLine{
+			Step:        "nested-stage-0",
+			ParentStage: "stage-a",
+			Type:        contracts.TypeService,
+			Depth: 1,
+		}
+
+		// act
+		pipelineRunner.upsertTailLogLine(tailLogLine)
+
+		assert.Equal(t, 1, len(pipelineRunner.buildLogSteps))
+		assert.Equal(t, "stage-a", pipelineRunner.buildLogSteps[0].Step)
+		assert.Equal(t, 0, pipelineRunner.buildLogSteps[0].Depth)
+	})
+
 	t.Run("AddsNestedStageIfDoesNotExist", func(t *testing.T) {
 
 		pipelineRunner := pipelineRunnerImpl{

--- a/pipelineRunner_test.go
+++ b/pipelineRunner_test.go
@@ -2605,6 +2605,70 @@ func TestIsFinalStageComplete(t *testing.T) {
 
 		assert.False(t, isComplete)
 	})
+
+	t.Run("ReturnsFalseIfLastStepHasSucceededStatusButMultiStageServicesFromPreviousStagesHaveNotFinished", func(t *testing.T) {
+
+		pipelineRunner := pipelineRunnerImpl{
+			buildLogSteps: []*contracts.BuildLogStep{
+				&contracts.BuildLogStep{
+					Step:   "earlier-stage",
+					Status: contracts.StatusSucceeded,
+					Services: []*contracts.BuildLogStep{
+						&contracts.BuildLogStep{
+							Step:   "nested-service-1",
+							Status: contracts.StatusRunning,
+						},
+					},
+				},
+				&contracts.BuildLogStep{
+					Step:   "last-stage",
+					Status: contracts.StatusSucceeded,
+				},
+			},
+		}
+		stages := []*manifest.EstafetteStage{
+			&manifest.EstafetteStage{
+				Name: "last-stage",
+			},
+		}
+
+		// act
+		isComplete := pipelineRunner.isFinalStageComplete(stages)
+
+		assert.False(t, isComplete)
+	})
+
+	t.Run("ReturnsTrueIfLastStepHasSucceededStatusAndAllServicesFromPreviousStagesHaveFinished", func(t *testing.T) {
+
+		pipelineRunner := pipelineRunnerImpl{
+			buildLogSteps: []*contracts.BuildLogStep{
+				&contracts.BuildLogStep{
+					Step:   "earlier-stage",
+					Status: contracts.StatusSucceeded,
+					Services: []*contracts.BuildLogStep{
+						&contracts.BuildLogStep{
+							Step:   "nested-service-1",
+							Status: contracts.StatusRunning,
+						},
+					},
+				},
+				&contracts.BuildLogStep{
+					Step:   "last-stage",
+					Status: contracts.StatusSucceeded,
+				},
+			},
+		}
+		stages := []*manifest.EstafetteStage{
+			&manifest.EstafetteStage{
+				Name: "last-stage",
+			},
+		}
+
+		// act
+		isComplete := pipelineRunner.isFinalStageComplete(stages)
+
+		assert.False(t, isComplete)
+	})
 }
 
 func getPipelineRunnerAndMocks() (*dockerRunnerMockImpl, chan contracts.TailLogLine, chan struct{}, PipelineRunner) {

--- a/pipelineRunner_test.go
+++ b/pipelineRunner_test.go
@@ -116,7 +116,7 @@ func TestRunStage(t *testing.T) {
 		dockerRunnerMock.startStageContainerFunc = func(ctx context.Context, depth int, runIndex int, dir string, envvars map[string]string, stage manifest.EstafetteStage) (containerID string, err error) {
 			return "abc", nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			return fmt.Errorf("Failed tailing container logs")
 		}
 
@@ -160,7 +160,7 @@ func TestRunStage(t *testing.T) {
 			startStageContainerFuncCalled = true
 			return "abc", nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			tailContainerLogsFuncCalled = true
 			return nil
 		}
@@ -198,7 +198,7 @@ func TestRunStage(t *testing.T) {
 		dockerRunnerMock.startStageContainerFunc = func(ctx context.Context, depth int, runIndex int, dir string, envvars map[string]string, stage manifest.EstafetteStage) (containerID string, err error) {
 			return "abc", nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			return nil
 		}
 
@@ -239,7 +239,7 @@ func TestRunStage(t *testing.T) {
 		dockerRunnerMock.startStageContainerFunc = func(ctx context.Context, depth int, runIndex int, dir string, envvars map[string]string, stage manifest.EstafetteStage) (containerID string, err error) {
 			return "abc", nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			return nil
 		}
 
@@ -283,7 +283,7 @@ func TestRunStage(t *testing.T) {
 		dockerRunnerMock.startStageContainerFunc = func(ctx context.Context, depth int, runIndex int, dir string, envvars map[string]string, stage manifest.EstafetteStage) (containerID string, err error) {
 			return "abc", nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			return fmt.Errorf("Failed tailing container logs")
 		}
 
@@ -327,7 +327,7 @@ func TestRunStage(t *testing.T) {
 		dockerRunnerMock.startStageContainerFunc = func(ctx context.Context, depth int, runIndex int, dir string, envvars map[string]string, stage manifest.EstafetteStage) (containerID string, err error) {
 			return "abc", nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			return nil
 		}
 
@@ -374,7 +374,7 @@ func TestRunStage(t *testing.T) {
 		dockerRunnerMock.startStageContainerFunc = func(ctx context.Context, depth int, runIndex int, dir string, envvars map[string]string, stage manifest.EstafetteStage) (containerID string, err error) {
 			return "abc", nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			return fmt.Errorf("Failed tailing container logs")
 		}
 
@@ -426,7 +426,7 @@ func TestRunStage(t *testing.T) {
 		dockerRunnerMock.startStageContainerFunc = func(ctx context.Context, depth int, runIndex int, dir string, envvars map[string]string, stage manifest.EstafetteStage) (containerID string, err error) {
 			return "abc", nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			return nil
 		}
 
@@ -470,7 +470,7 @@ func TestRunStageWithRetry(t *testing.T) {
 
 		// set mock responses
 		callCount := 0
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			callCount++
 			return fmt.Errorf("Failed tailing container logs")
 		}
@@ -500,7 +500,7 @@ func TestRunStageWithRetry(t *testing.T) {
 		// set mock responses
 		iteration := 0
 		callCount := 0
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 
 			defer func() { iteration++ }()
 			callCount++
@@ -542,7 +542,7 @@ func TestRunStageWithRetry(t *testing.T) {
 		// set mock responses
 		iteration := 0
 		callCount := 0
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 
 			defer func() { iteration++ }()
 			callCount++
@@ -581,7 +581,7 @@ func TestRunStageWithRetry(t *testing.T) {
 		}
 
 		// set mock responses
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			return fmt.Errorf("Failed tailing container logs")
 		}
 
@@ -614,7 +614,7 @@ func TestRunStageWithRetry(t *testing.T) {
 
 		// set mock responses
 		iteration := 0
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 
 			defer func() { iteration++ }()
 
@@ -763,7 +763,7 @@ func TestRunService(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			defer wg.Done()
 			return fmt.Errorf("Failed tailing container logs")
 		}
@@ -798,7 +798,7 @@ func TestRunService(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			defer wg.Done()
 			return nil
 		}
@@ -852,7 +852,7 @@ func TestRunService(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			defer wg.Done()
 			tailContainerLogsFuncCalled = true
 			return nil
@@ -900,7 +900,7 @@ func TestRunService(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			defer wg.Done()
 			return nil
 		}
@@ -944,7 +944,7 @@ func TestRunService(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			defer wg.Done()
 			return nil
 		}
@@ -994,7 +994,7 @@ func TestRunService(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			defer wg.Done()
 			// ensure tailing doesn't set status before the main routine does
 			time.Sleep(100 * time.Millisecond)
@@ -1048,7 +1048,7 @@ func TestRunService(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			defer wg.Done()
 			// ensure tailing doesn't set status before the main routine does
 			time.Sleep(100 * time.Millisecond)
@@ -1103,7 +1103,7 @@ func TestRunService(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			defer wg.Done()
 			// ensure tailing doesn't set status before the main routine does
 			time.Sleep(100 * time.Millisecond)
@@ -1191,6 +1191,33 @@ func TestRunStages(t *testing.T) {
 		_, _ = pipelineRunner.RunStages(context.Background(), depth, stages, dir, envvars)
 
 		assert.True(t, deleteBridgeNetworkFuncCalled)
+	})
+
+	t.Run("CallsStopMultiStageServiceContainers", func(t *testing.T) {
+
+		dockerRunnerMock, _, _, pipelineRunner := getPipelineRunnerAndMocks()
+
+		depth := 0
+		dir := "/estafette-work"
+		envvars := map[string]string{}
+		stages := []*manifest.EstafetteStage{
+			&manifest.EstafetteStage{
+				Name:           "stage-a",
+				ContainerImage: "alpine:latest",
+				When:           "status == 'succeeded'",
+			},
+		}
+
+		// set mock responses
+		stopMultiStageServiceContainersFuncCalled := false
+		dockerRunnerMock.stopMultiStageServiceContainersFunc = func(ctx context.Context) {
+			stopMultiStageServiceContainersFuncCalled = true
+		}
+
+		// act
+		_, _ = pipelineRunner.RunStages(context.Background(), depth, stages, dir, envvars)
+
+		assert.True(t, stopMultiStageServiceContainersFuncCalled)
 	})
 
 	t.Run("ReturnsErrorWhenFirstStageFails", func(t *testing.T) {
@@ -1391,7 +1418,7 @@ func TestRunStages(t *testing.T) {
 			time.Sleep(50 * time.Millisecond)
 			return nil
 		}
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			time.Sleep(100 * time.Millisecond)
 			return nil
 		}
@@ -1568,13 +1595,13 @@ func TestRunStagesWithServices(t *testing.T) {
 		}
 		var wg sync.WaitGroup
 		wg.Add(1)
-		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int) (err error) {
+		dockerRunnerMock.tailContainerLogsFunc = func(ctx context.Context, containerID, parentStageName, stageName, stageType string, depth, runIndex int, multiStage *bool) (err error) {
 			if stageType == contracts.TypeService {
 				wg.Wait()
 			}
 			return nil
 		}
-		dockerRunnerMock.stopServiceContainersFunc = func(ctx context.Context, parentStage manifest.EstafetteStage) {
+		dockerRunnerMock.stopSingleStageServiceContainersFunc = func(ctx context.Context, parentStage manifest.EstafetteStage) {
 			wg.Done()
 		}
 

--- a/templates/estafette-entrypoint.sh
+++ b/templates/estafette-entrypoint.sh
@@ -6,7 +6,7 @@ set -e
 echo -e "\x1b[38;5;250m> {{.EscapedCommand}} &\x1b[0m"
 {{.Command}} &
 trap "kill $!; wait; exit" 1 2 15
-wait
+wait $!
 {{- else }}
 echo -e "\x1b[38;5;250m> {{.EscapedCommand}}\x1b[0m"
 {{.Command}}

--- a/templates/estafette-entrypoint.sh
+++ b/templates/estafette-entrypoint.sh
@@ -3,21 +3,21 @@ set -e
 
 {{- range .Commands }}
 {{- if .RunInBackground}}
-echo -e $'\x1b[38;5;250m> {{.EscapedCommand}} &\x1b[0m'
+echo -e "\x1b[38;5;250m> {{.EscapedCommand}} &\x1b[0m"
 {{.Command}} &
 trap "kill $!; wait; exit" 1 2 15
 wait
 {{- else }}
-echo -e $'\x1b[38;5;250m> {{.EscapedCommand}}\x1b[0m'
+echo -e "\x1b[38;5;250m> {{.EscapedCommand}}\x1b[0m"
 {{.Command}}
 {{- end }}
 {{- end }}
 {{- if .RunFinalCommandWithExec}}
 
-echo -e $'\x1b[38;5;250m> exec {{.EscapedFinalCommand}}\x1b[0m'
+echo -e "\x1b[38;5;250m> exec {{.EscapedFinalCommand}}\x1b[0m"
 exec {{.FinalCommand}}
 {{- else }}
 
-echo -e $'\x1b[38;5;250m> {{.EscapedFinalCommand}}\x1b[0m'
+echo -e "\x1b[38;5;250m> {{.EscapedFinalCommand}}\x1b[0m"
 {{.FinalCommand}}
 {{- end }}

--- a/templates/estafette-entrypoint.sh
+++ b/templates/estafette-entrypoint.sh
@@ -3,21 +3,21 @@ set -e
 
 {{- range .Commands }}
 {{- if .RunInBackground}}
-echo -e '\x1b[38;5;250m> {{.EscapedCommand}} &\x1b[0m'
+echo -e $'\x1b[38;5;250m> {{.EscapedCommand}} &\x1b[0m'
 {{.Command}} &
 trap "kill $!; wait; exit" 1 2 15
 wait
 {{- else }}
-echo -e '\x1b[38;5;250m> {{.EscapedCommand}}\x1b[0m'
+echo -e $'\x1b[38;5;250m> {{.EscapedCommand}}\x1b[0m'
 {{.Command}}
 {{- end }}
 {{- end }}
 {{- if .RunFinalCommandWithExec}}
 
-echo -e '\x1b[38;5;250m> exec {{.EscapedFinalCommand}}\x1b[0m'
+echo -e $'\x1b[38;5;250m> exec {{.EscapedFinalCommand}}\x1b[0m'
 exec {{.FinalCommand}}
 {{- else }}
 
-echo -e '\x1b[38;5;250m> {{.EscapedFinalCommand}}\x1b[0m'
+echo -e $'\x1b[38;5;250m> {{.EscapedFinalCommand}}\x1b[0m'
 {{.FinalCommand}}
 {{- end }}


### PR DESCRIPTION
To stop containers more selectively the docker runner keeps track of the following running containers separately:
- stage containers
- readiness probe containers
- single-stage service containers
- multi-stage service containers