### PR TITLE
use container-registry-pull credential type

### DIFF
--- a/builder/dockerRunner.go
+++ b/builder/dockerRunner.go
@@ -753,6 +753,7 @@ func (dr *dockerRunnerImpl) getImagePullOptions(containerImage string) types.Ima
 		}
 	}
 
+	// when no container-registry credentials apply use container-registry-pull as fallback to avoid docker hub rate limiting issues
 	containerRegistryPullCredentials := dr.config.GetCredentialsByType("container-registry-pull")
 
 	if len(containerRegistryPullCredentials) > 0 {


### PR DESCRIPTION
to authenticate towards docker hub if no other credentials apply, so rate limiting issues can be avoided